### PR TITLE
Authentication at Servant API level

### DIFF
--- a/csdc-api/app/Main.hs
+++ b/csdc-api/app/Main.hs
@@ -4,7 +4,6 @@ module Main where
 
 import CSDC.API (API, serveAPI)
 import CSDC.Config (Config (..), readConfig, showConfig)
-import CSDC.Network.Class (checkPerson)
 import CSDC.Network.Mock (Store, makeEmptyStore, runMock)
 
 import qualified CSDC.Auth as Auth
@@ -55,8 +54,6 @@ application :: FilePath -> MVar Store -> Application
 application path store = \request response ->
   let
     proxy = Proxy @API
-    token = Auth.getUserToken request
     server = hoistServer proxy (runMock store) (serveAPI path)
   in do
-    runMock store (checkPerson token)
     serve proxy server request response

--- a/csdc-api/src/CSDC/API.hs
+++ b/csdc-api/src/CSDC/API.hs
@@ -1,13 +1,21 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module CSDC.API
   ( API
   , serveAPI
   ) where
 
+import CSDC.Auth (getUserToken)
 import CSDC.Prelude
 
 import qualified CSDC.API.Network as Network
 
 import Servant
+import Servant.Server.Internal.Delayed (passToServer)
 
 import WaiAppStatic.Types (StaticSettings (..), unsafeToPiece)
 import WaiAppStatic.Storage.Filesystem (defaultWebAppSettings)
@@ -16,12 +24,13 @@ import WaiAppStatic.Storage.Filesystem (defaultWebAppSettings)
 -- API
 
 type API =
-       "api" :> Network.API
+       UserCredentials :> "api" :> Network.API
   :<|> Raw
 
 serveAPI :: MonadNetwork m => FilePath -> ServerT API m
 serveAPI path =
-       Network.serveAPI
+       -- XXX: use credentials
+       (\_ -> Network.serveAPI)
   :<|> serveDirectoryWith (options path)
 
 options :: FilePath -> StaticSettings
@@ -34,3 +43,16 @@ options path =
       pcs -> old pcs
   in
     base { ssLookupFile = indexRedirect (ssLookupFile base) }
+
+--------------------------------------------------------------------------------
+-- UserCredentials
+
+-- | This type is used for representing credentials at the servant API level.
+data UserCredentials
+
+instance HasServer api context => HasServer (UserCredentials :> api) context where
+  type ServerT (UserCredentials :> api) m = UserToken -> ServerT api m
+
+  route Proxy context subserver =
+    route (Proxy @api) context (passToServer subserver getUserToken)
+  hoistServerWithContext _ pc nt s = hoistServerWithContext (Proxy :: Proxy api) pc nt . s

--- a/csdc-api/src/CSDC/API.hs
+++ b/csdc-api/src/CSDC/API.hs
@@ -30,7 +30,7 @@ type API =
        Auth :> "api" :> Network.API
   :<|> Raw
 
-serveAPI :: MonadNetwork m => FilePath -> ServerT API m
+serveAPI :: HasNetwork m => FilePath -> ServerT API m
 serveAPI path =
          serveNetworkAPI
     :<|> serveDirectoryWith (options path)

--- a/csdc-api/src/CSDC/API/Network.hs
+++ b/csdc-api/src/CSDC/API/Network.hs
@@ -5,7 +5,7 @@ module CSDC.API.Network
 
 import CSDC.Data.Id (Id)
 import CSDC.Data.IdMap (IdMap)
-import CSDC.Network.Class (MonadNetwork (..))
+import CSDC.Network.Class (HasNetwork (..))
 import CSDC.Network.Types (Person, Unit, Member, Subpart)
 
 import GHC.Types (Symbol)
@@ -22,7 +22,7 @@ type CRUD (name :: Symbol) a =
 
 type PersonAPI = CRUD "person" Person
 
-servePersonAPI :: MonadNetwork m => ServerT PersonAPI m
+servePersonAPI :: HasNetwork m => ServerT PersonAPI m
 servePersonAPI =
        selectPerson
   :<|> insertPerson
@@ -33,7 +33,7 @@ type UnitAPI =
        "unit" :> "root" :> Get '[JSON] (Id Unit)
   :<|> CRUD "unit" Unit
 
-serveUnitAPI :: MonadNetwork m => ServerT UnitAPI m
+serveUnitAPI :: HasNetwork m => ServerT UnitAPI m
 serveUnitAPI =
        rootUnit
   :<|> selectUnit
@@ -52,7 +52,7 @@ type REL (name :: Symbol) (left :: Symbol) (right :: Symbol) r a b =
 
 type MemberAPI = REL "member" "person" "unit" Member Person Unit
 
-serveMemberAPI :: MonadNetwork m => ServerT MemberAPI m
+serveMemberAPI :: HasNetwork m => ServerT MemberAPI m
 serveMemberAPI =
        selectMemberPerson
   :<|> selectMemberUnit
@@ -61,7 +61,7 @@ serveMemberAPI =
 
 type SubpartAPI = REL "subpart" "child" "parent" Subpart Unit Unit
 
-serveSubpartAPI :: MonadNetwork m => ServerT SubpartAPI m
+serveSubpartAPI :: HasNetwork m => ServerT SubpartAPI m
 serveSubpartAPI =
        selectSubpartChild
   :<|> selectSubpartParent
@@ -73,7 +73,7 @@ serveSubpartAPI =
 
 type API = PersonAPI :<|> UnitAPI :<|> MemberAPI :<|> SubpartAPI
 
-serveAPI :: MonadNetwork m => ServerT API m
+serveAPI :: HasNetwork m => ServerT API m
 serveAPI =
        servePersonAPI
   :<|> serveUnitAPI

--- a/csdc-api/src/CSDC/API/Network.hs
+++ b/csdc-api/src/CSDC/API/Network.hs
@@ -3,10 +3,7 @@ module CSDC.API.Network
   , serveAPI
   ) where
 
-import CSDC.Data.Id (Id)
-import CSDC.Data.IdMap (IdMap)
-import CSDC.Network.Class (HasNetwork (..))
-import CSDC.Network.Types (Person, Unit, Member, Subpart)
+import CSDC.Prelude hiding (JSON)
 
 import GHC.Types (Symbol)
 import Servant
@@ -20,11 +17,14 @@ type CRUD (name :: Symbol) a =
   :<|> name :> Capture "id" (Id a) :> ReqBody '[JSON] a :> Post '[JSON] ()
   :<|> name :> Capture "id" (Id a) :> Delete '[JSON] ()
 
-type PersonAPI = CRUD "person" Person
+type PersonAPI =
+       "person" :> "root" :> Get '[JSON] UserId
+  :<|> CRUD "person" Person
 
-servePersonAPI :: HasNetwork m => ServerT PersonAPI m
+servePersonAPI :: (HasUser m, HasNetwork m) => ServerT PersonAPI m
 servePersonAPI =
-       selectPerson
+       getUser
+  :<|> selectPerson
   :<|> insertPerson
   :<|> updatePerson
   :<|> deletePerson
@@ -73,7 +73,7 @@ serveSubpartAPI =
 
 type API = PersonAPI :<|> UnitAPI :<|> MemberAPI :<|> SubpartAPI
 
-serveAPI :: HasNetwork m => ServerT API m
+serveAPI :: (HasUser m, HasNetwork m) => ServerT API m
 serveAPI =
        servePersonAPI
   :<|> serveUnitAPI

--- a/csdc-auth/src/CSDC/Auth.hs
+++ b/csdc-auth/src/CSDC/Auth.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module CSDC.Auth
-  ( Config (..)
+  ( -- * Authentication middleware
+    Config (..)
   , middleware
+    -- * Authentication tokens
+  , UserToken
   , getUserToken
   ) where
 
@@ -72,7 +75,9 @@ settings config =
 middleware :: Config -> IO Middleware
 middleware = mkAuthMiddleware . settings
 
-getUserToken :: HasCallStack => Request -> User ORCID.Token
+type UserToken = User ORCID.Token
+
+getUserToken :: HasCallStack => Request -> UserToken
 getUserToken request =
   case getAccessToken request of
     Nothing ->

--- a/csdc-base/csdc-base.cabal
+++ b/csdc-base/csdc-base.cabal
@@ -28,6 +28,7 @@ library
     CSDC.Network.Mock
     CSDC.Network.Types
     CSDC.Prelude
+    CSDC.User
   build-depends:
     csdc-auth,
     aeson,

--- a/csdc-base/src/CSDC/Data/IdMap.hs
+++ b/csdc-base/src/CSDC/Data/IdMap.hs
@@ -32,8 +32,11 @@ empty = IdMap (IntMap.empty)
 lookup :: Id a -> IdMap a -> Maybe a
 lookup (Id uid) (IdMap m) = IntMap.lookup uid m
 
-find :: (a -> Bool) -> IdMap a -> Maybe a
-find p (IdMap m) = List.find p $ IntMap.elems m
+find :: (a -> Bool) -> IdMap a -> Maybe (Id a, a)
+find p (IdMap m) =
+  fmap (\(uid,a) -> (Id uid,a)) $
+  List.find (p . snd) $
+  IntMap.toList m
 
 insert :: Id a -> a -> IdMap a -> IdMap a
 insert (Id uid) a (IdMap m) = IdMap $ IntMap.insert uid a m

--- a/csdc-base/src/CSDC/Network/Class.hs
+++ b/csdc-base/src/CSDC/Network/Class.hs
@@ -1,5 +1,5 @@
 module CSDC.Network.Class
-  ( MonadNetwork (..)
+  ( HasNetwork (..)
   ) where
 
 import CSDC.Data.Id (Id)
@@ -14,7 +14,7 @@ import Control.Monad.Trans (MonadTrans (..))
 --------------------------------------------------------------------------------
 -- Class
 
-class Monad m => MonadNetwork m where
+class Monad m => HasNetwork m where
 
   -- Person manipulation
 
@@ -61,7 +61,7 @@ class Monad m => MonadNetwork m where
 
 -- | This instance is here for the delegation to @UserT@. It only depends on
 -- 'MonadTrans'.
-instance MonadNetwork m => MonadNetwork (ReaderT r m) where
+instance HasNetwork m => HasNetwork (ReaderT r m) where
   selectPerson  = lift1 selectPerson
   selectPersonORCID = lift1 selectPersonORCID
   insertPerson = lift1 insertPerson

--- a/csdc-base/src/CSDC/Network/Mock.hs
+++ b/csdc-base/src/CSDC/Network/Mock.hs
@@ -65,7 +65,7 @@ instance MonadIO m => MonadNetwork (Mock m) where
     IdMap.lookup uid <$> use store_person
 
   selectPersonORCID uid =
-    IdMap.find (\p -> person_orcid p == uid) <$> use store_person
+    fmap fst <$> IdMap.find (\p -> person_orcid p == uid) <$> use store_person
 
   insertPerson p =
     stating store_person (IdMap.insertNew p)

--- a/csdc-base/src/CSDC/Network/Mock.hs
+++ b/csdc-base/src/CSDC/Network/Mock.hs
@@ -13,7 +13,7 @@ import CSDC.Data.Id (Id (..))
 import CSDC.Data.IdMap (IdMap)
 import CSDC.Data.RIO (RIO, runRIO)
 import CSDC.Network.Types (Person (..), Unit (..), Member (..), Subpart (..))
-import CSDC.Network.Class (MonadNetwork (..))
+import CSDC.Network.Class (HasNetwork (..))
 
 import qualified CSDC.Data.IdMap as IdMap
 
@@ -57,7 +57,7 @@ newtype Mock m a = Mock (RIO Store m a)
 runMock :: MonadIO m => MVar Store -> Mock m a -> m a
 runMock var (Mock m) = runRIO var m
 
-instance MonadIO m => MonadNetwork (Mock m) where
+instance MonadIO m => HasNetwork (Mock m) where
 
   -- Person manipulation
 

--- a/csdc-base/src/CSDC/Prelude.hs
+++ b/csdc-base/src/CSDC/Prelude.hs
@@ -8,7 +8,7 @@ import CSDC.Network.Types as Export
 import CSDC.Data.Id as Export (Id (..))
 import CSDC.Data.IdMap as Export (IdMap (..))
 import CSDC.Auth as Export (UserToken)
-import CSDC.Auth.User as Export
+import CSDC.User as Export (HasUser (..), User (..), UserId)
 
 import Control.Monad.IO.Class as Export (MonadIO (..))
 import Data.Aeson as Export (FromJSON, ToJSON)

--- a/csdc-base/src/CSDC/Prelude.hs
+++ b/csdc-base/src/CSDC/Prelude.hs
@@ -7,6 +7,7 @@ import CSDC.Network.Class as Export
 import CSDC.Network.Types as Export
 import CSDC.Data.Id as Export (Id (..))
 import CSDC.Data.IdMap as Export (IdMap (..))
+import CSDC.Auth as Export (UserToken)
 import CSDC.Auth.User as Export
 
 import Control.Monad.IO.Class as Export (MonadIO (..))

--- a/csdc-base/src/CSDC/User.hs
+++ b/csdc-base/src/CSDC/User.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE LambdaCase #-}
+
+module CSDC.User
+  ( -- * Type
+    User (..)
+  , UserId
+    -- * Class
+  , HasUser (..)
+    -- * Transformer
+  , UserT
+  , runUserT
+  ) where
+
+import CSDC.Auth (UserToken)
+import CSDC.Auth.User (User (..))
+import CSDC.Network.Class (MonadNetwork (..))
+import CSDC.Network.Types (Person (..))
+import CSDC.Data.Id (Id)
+
+import qualified CSDC.Auth.ORCID as ORCID
+
+import Control.Monad.Reader (MonadReader (..), ReaderT (..))
+import Control.Monad.Trans (MonadTrans (..))
+
+--------------------------------------------------------------------------------
+-- Class
+
+type UserId = User (Id Person)
+
+-- | A class for monads that have an user in scope.
+class Monad m => HasUser m where
+  -- | Get the current user in scope.
+  getUser :: m UserId
+
+--------------------------------------------------------------------------------
+-- Transformer
+
+-- | A transformer that adds the 'HasUser' capability to another monad.
+newtype UserT m a = UserT (ReaderT UserToken m a)
+  deriving newtype
+    ( Functor
+    , Applicative
+    , Monad
+    , MonadTrans
+    , MonadNetwork
+    )
+
+instance MonadNetwork m => HasUser (UserT m) where
+  getUser = UserT $
+    ask >>= \case
+      Admin ->
+        pure Admin
+
+      User token ->
+        selectPersonORCID (ORCID.token_orcid token) >>= \case
+          Nothing ->
+            let
+              person = Person
+                { person_name = ORCID.token_name token
+                , person_orcid = ORCID.token_orcid token
+                }
+            in
+              User <$> insertPerson person
+          Just uid ->
+            pure $ User uid
+
+-- | Execute an 'UserT' in its base monad.
+runUserT :: UserToken -> UserT m a -> m a
+runUserT user (UserT act) = runReaderT act user

--- a/csdc-base/src/CSDC/User.hs
+++ b/csdc-base/src/CSDC/User.hs
@@ -13,7 +13,7 @@ module CSDC.User
 
 import CSDC.Auth (UserToken)
 import CSDC.Auth.User (User (..))
-import CSDC.Network.Class (MonadNetwork (..))
+import CSDC.Network.Class (HasNetwork (..))
 import CSDC.Network.Types (Person (..))
 import CSDC.Data.Id (Id)
 
@@ -42,10 +42,10 @@ newtype UserT m a = UserT (ReaderT UserToken m a)
     , Applicative
     , Monad
     , MonadTrans
-    , MonadNetwork
+    , HasNetwork
     )
 
-instance MonadNetwork m => HasUser (UserT m) where
+instance HasNetwork m => HasUser (UserT m) where
   getUser = UserT $
     ask >>= \case
       Admin ->


### PR DESCRIPTION
This adds authentication at the level of Servant's API. No routes are checked yet, but the user id is accessible to any routes under the `Auth` part of the API.

The access to the user is done through the `HasUser` class.

A new route has been added, which gives the GUI access to the user. This route should be accessed on the startup (to be done yet).

Closes #3.