### PR TITLE
Add utilities for form validation

### DIFF
--- a/csdc-gui/src/CSDC/Component/Admin/NewMember.elm
+++ b/csdc-gui/src/CSDC/Component/Admin/NewMember.elm
@@ -12,11 +12,11 @@ import CSDC.Notification as Notification
 import CSDC.Notification exposing (Notification)
 import CSDC.Types exposing (..)
 import Field exposing (Field)
+import Input
 import Validation exposing (Validation)
 
 import Element exposing (..)
 import Element.Font as Font
-import Element.Input as Input
 import String
 
 --------------------------------------------------------------------------------
@@ -104,20 +104,15 @@ view model =
     [ row
         [ Font.bold, Font.size 30 ]
         [ text "New Member" ]
+
     , Input.text
-        []
         { onChange = InputPerson
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Person")
-        , text = Field.raw model.person
+        , field = model.person
         }
 
     , Input.text
-        []
         { onChange = InputUnit
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Unit")
-        , text = Field.raw model.unit
+        , field = model.unit
         }
 
     , CSDC.Input.button Submit "Submit"

--- a/csdc-gui/src/CSDC/Component/Admin/NewMessage.elm
+++ b/csdc-gui/src/CSDC/Component/Admin/NewMessage.elm
@@ -12,11 +12,11 @@ import CSDC.Notification as Notification
 import CSDC.Notification exposing (Notification)
 import CSDC.Types exposing (..)
 import Field exposing (Field)
+import Input
 import Validation exposing (Validation)
 
 import Element exposing (..)
 import Element.Font as Font
-import Element.Input as Input
 import String
 
 --------------------------------------------------------------------------------
@@ -145,50 +145,35 @@ view model =
     , selectMessageType model
     , selectMessageStatus model
     , Input.text
-        []
         { onChange = InputPerson
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Person")
-        , text = Field.raw model.person
+        , field = model.person
         }
-
     , Input.text
-        []
         { onChange = InputUnit
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Unit")
-        , text = Field.raw model.unit
+        , field = model.unit
         }
     , CSDC.Input.button Submit "Submit"
     ] ++ Notification.view model.notification
 
 selectMessageType : Model -> Element Msg
 selectMessageType model =
-  Input.radioRow
-    [ padding 10
-    , spacing 20
-    ]
+  Input.radio
     { onChange = InputMessageType
-    , selected = Field.raw model.messageType
-    , label = Input.labelAbove [] (text "Message Type")
+    , field = model.messageType
     , options =
-        [ Input.option Invitation (text "Invitation")
-        , Input.option Submission (text "Submission")
+        [ (Invitation, "Invitation")
+        , (Submission, "Submission")
         ]
     }
 
 selectMessageStatus : Model -> Element Msg
 selectMessageStatus model =
-  Input.radioRow
-    [ padding 10
-    , spacing 20
-    ]
+  Input.radio
     { onChange = InputMessageStatus
-    , selected = Field.raw model.messageStatus
-    , label = Input.labelAbove [] (text "Message Status")
+    , field = model.messageStatus
     , options =
-        [ Input.option Waiting (text "Waiting")
-        , Input.option Accepted (text "Accepted")
-        , Input.option Rejected (text "Rejected")
+        [ (Waiting, "Waiting")
+        , (Accepted, "Accepted")
+        , (Rejected, "Rejected")
         ]
     }

--- a/csdc-gui/src/CSDC/Component/Admin/NewPerson.elm
+++ b/csdc-gui/src/CSDC/Component/Admin/NewPerson.elm
@@ -11,6 +11,8 @@ import CSDC.Input
 import CSDC.Notification as Notification
 import CSDC.Notification exposing (Notification)
 import CSDC.Types exposing (..)
+import Field exposing (Field)
+import Validation exposing (Validation)
 
 import Element exposing (..)
 import Element.Font as Font
@@ -21,13 +23,13 @@ import String
 -- Model
 
 type alias Model =
-  { name : Maybe String
+  { name : Field String String
   , notification : Notification
   }
 
 initial : Model
 initial =
-  { name = Nothing
+  { name = Field.requiredString "Name"
   , notification = Notification.Empty
   }
 
@@ -44,23 +46,17 @@ update : Msg -> Model -> (Model, Cmd Msg)
 update msg model =
   case msg of
     InputName name ->
-      let
-        newName =
-          if String.isEmpty name
-          then Nothing
-          else Just name
-      in
-        ( { model | name = newName }
-        , Cmd.none
-        )
+      ( { model | name = Field.set name model.name }
+      , Cmd.none
+      )
 
     Submit ->
-      case model.name of
-        Nothing ->
-          ( { model | notification = Notification.Error "Name must not be empty!" }
+      case Validation.validate (Field.validate model.name) of
+        Err e ->
+          ( { model | notification = Notification.Error e }
           , Cmd.none
           )
-        Just name ->
+        Ok name ->
           ( { model | notification = Notification.Processing }
           , Cmd.map APIMsg <| API.insertPerson (Person name "ORCID" "")
           )
@@ -99,7 +95,7 @@ view model =
         { onChange = InputName
         , placeholder = Nothing
         , label = Input.labelAbove [] (text "Name")
-        , text = Maybe.withDefault "" model.name
+        , text = Field.raw model.name
         }
     , CSDC.Input.button Submit "Submit"
     ] ++ Notification.view model.notification

--- a/csdc-gui/src/CSDC/Component/Admin/NewPerson.elm
+++ b/csdc-gui/src/CSDC/Component/Admin/NewPerson.elm
@@ -12,11 +12,11 @@ import CSDC.Notification as Notification
 import CSDC.Notification exposing (Notification)
 import CSDC.Types exposing (..)
 import Field exposing (Field)
+import Input
 import Validation exposing (Validation)
 
 import Element exposing (..)
 import Element.Font as Font
-import Element.Input as Input
 import String
 
 --------------------------------------------------------------------------------
@@ -91,11 +91,8 @@ view model =
         [ Font.bold, Font.size 30 ]
         [ text "New Person" ]
     , Input.text
-        []
         { onChange = InputName
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Name")
-        , text = Field.raw model.name
+        , field = model.name
         }
     , CSDC.Input.button Submit "Submit"
     ] ++ Notification.view model.notification

--- a/csdc-gui/src/CSDC/Component/Admin/NewReply.elm
+++ b/csdc-gui/src/CSDC/Component/Admin/NewReply.elm
@@ -12,11 +12,11 @@ import CSDC.Notification as Notification
 import CSDC.Notification exposing (Notification)
 import CSDC.Types exposing (..)
 import Field exposing (Field)
+import Input
 import Validation exposing (Validation)
 
 import Element exposing (..)
 import Element.Font as Font
-import Element.Input as Input
 import String
 
 --------------------------------------------------------------------------------
@@ -142,56 +142,41 @@ view model =
     , selectReplyType model
     , selectReplyStatus model
     , Input.text
-        []
         { onChange = InputMessage
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Message")
-        , text = Field.raw model.message
+        , field = model.message
         }
     , CSDC.Input.button Submit "Submit"
     ] ++ Notification.view model.notification
 
 selectReplyType : Model -> Element Msg
 selectReplyType model =
-  Input.radioRow
-    [ padding 10
-    , spacing 20
-    ]
+  Input.radio
     { onChange = InputReplyType
-    , selected = Field.raw model.replyType
-    , label = Input.labelAbove [] (text "Reply Type")
+    , field = model.replyType
     , options =
-        [ Input.option Accept (text "Accept")
-        , Input.option Reject (text "Reject")
+        [ (Accept, "Accept")
+        , (Reject, "Reject")
         ]
     }
 
 selectMessageType : Model -> Element Msg
 selectMessageType model =
-  Input.radioRow
-    [ padding 10
-    , spacing 20
-    ]
+  Input.radio
     { onChange = InputMessageType
-    , selected = Field.raw model.messageType
-    , label = Input.labelAbove [] (text "Message Type")
+    , field = model.messageType
     , options =
-        [ Input.option Invitation (text "Invitation")
-        , Input.option Submission (text "Submission")
+        [ (Invitation, "Invitation")
+        , (Submission, "Submission")
         ]
     }
 
 selectReplyStatus : Model -> Element Msg
 selectReplyStatus model =
-  Input.radioRow
-    [ padding 10
-    , spacing 20
-    ]
+  Input.radio
     { onChange = InputReplyStatus
-    , selected = Field.raw model.replyStatus
-    , label = Input.labelAbove [] (text "Reply Status")
+    , field = model.replyStatus
     , options =
-        [ Input.option Seen (text "Seen")
-        , Input.option NotSeen (text "Not Seen")
+        [ (Seen, "Seen")
+        , (NotSeen, "Not Seen")
         ]
     }

--- a/csdc-gui/src/CSDC/Component/Admin/NewSubpart.elm
+++ b/csdc-gui/src/CSDC/Component/Admin/NewSubpart.elm
@@ -12,11 +12,11 @@ import CSDC.Notification as Notification
 import CSDC.Notification exposing (Notification)
 import CSDC.Types exposing (..)
 import Field exposing (Field)
+import Input
 import Validation exposing (Validation)
 
 import Element exposing (..)
 import Element.Font as Font
-import Element.Input as Input
 import String
 
 --------------------------------------------------------------------------------
@@ -104,20 +104,15 @@ view model =
     [ row
         [ Font.bold, Font.size 30 ]
         [ text "New Subpart" ]
+
     , Input.text
-        []
         { onChange = InputChild
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Child")
-        , text = Field.raw model.child
+        , field = model.child
         }
 
     , Input.text
-        []
         { onChange = InputParent
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Parent")
-        , text = Field.raw model.parent
+        , field = model.parent
         }
 
     , CSDC.Input.button Submit "Submit"

--- a/csdc-gui/src/CSDC/Component/Admin/NewUnit.elm
+++ b/csdc-gui/src/CSDC/Component/Admin/NewUnit.elm
@@ -12,11 +12,11 @@ import CSDC.Notification as Notification
 import CSDC.Notification exposing (Notification)
 import CSDC.Types exposing (..)
 import Field exposing (Field)
+import Input
 import Validation exposing (Validation)
 
 import Element exposing (..)
 import Element.Font as Font
-import Element.Input as Input
 import String
 
 --------------------------------------------------------------------------------
@@ -91,11 +91,8 @@ view model =
         [ Font.bold, Font.size 30 ]
         [ text "New Unit" ]
     , Input.text
-        []
         { onChange = InputId
-        , placeholder = Nothing
-        , label = Input.labelAbove [] (text "Chair Id")
-        , text = Field.raw model.chair
+        , field = model.chair
         }
     , CSDC.Input.button Submit "Submit"
     ] ++ Notification.view model.notification

--- a/csdc-gui/src/CSDC/Form.elm
+++ b/csdc-gui/src/CSDC/Form.elm
@@ -1,1 +1,0 @@
-module CSDC.Form exposing (..)

--- a/csdc-gui/src/CSDC/Notification.elm
+++ b/csdc-gui/src/CSDC/Notification.elm
@@ -12,7 +12,7 @@ type Notification
   = Empty
   | Processing
   | Success
-  | Error String
+  | Error (List String)
   | HttpError Http.Error
 
 view : Notification -> List (Element msg)
@@ -27,8 +27,8 @@ view notification =
     Success ->
       [ text "Success!" ]
 
-    Error msg ->
-      [ text <| "Error: " ++ msg ]
+    Error msgs ->
+      [ text "Error: " ] ++ List.map text msgs
 
     HttpError err ->
       case err of

--- a/csdc-gui/src/Field.elm
+++ b/csdc-gui/src/Field.elm
@@ -1,0 +1,101 @@
+module Field exposing
+  ( Field
+  , Status
+  , name
+  , raw
+  , set
+  , errors
+  , validate
+    -- Common
+  , make
+  , required
+  , requiredString
+  , requiredId
+  )
+
+import CSDC.Types exposing (Id (..))
+import Validation exposing (Validation)
+
+type Status b
+  -- The field was incorrectly parsed.
+  = Invalid (List String)
+  -- The field was correctly parsed.
+  | Valid b
+  -- Exists so that initial values do not show errors from the start.
+  | Initial (List String)
+
+type Field a b = Field
+  { -- Name of the field, used for UI and errors.
+    name : String
+    -- The value that was input by the user.
+  , raw : a
+    -- The validation status of the field.
+  , status : Status b
+    -- The validation function of the field.
+  , validate : a -> Validation b
+  }
+
+name : Field a b -> String
+name (Field f) = f.name
+
+raw : Field a b -> a
+raw (Field f) = f.raw
+
+set : a -> Field a b -> Field a b
+set a (Field f) = Field
+  { name = f.name
+  , raw = a
+  , status =
+      case Validation.validate (f.validate a) of
+        Err e -> Invalid e
+        Ok b -> Valid b
+  , validate = f.validate
+  }
+
+errors : Field a b -> List String
+errors (Field f) =
+  case f.status of
+    Invalid e -> e
+    _ -> []
+
+validate : Field a b -> Validation b
+validate (Field f) =
+  let
+    addPrefix s = f.name ++ ": " ++ s
+  in
+    case f.status of
+      Invalid e -> Validation.make <| Err (List.map addPrefix e)
+      Valid a -> Validation.make <| Ok a
+      Initial e -> Validation.make <| Err (List.map addPrefix e)
+
+--------------------------------------------------------------------------------
+-- Fields
+
+make : String -> a -> (a -> Validation b) -> Field a b
+make n r v = Field
+  { name = n
+  , raw = r
+  , validate = v
+  , status =
+      case Validation.validate (v r) of
+        Err e -> Initial e
+        Ok b -> Valid b
+  }
+
+required : String -> Field (Maybe a) a
+required n = make n Nothing <| \m ->
+  case m of
+    Nothing -> Validation.invalid "Field is required."
+    Just a -> Validation.valid a
+
+requiredString : String -> Field String String
+requiredString n = make n "" <| \s ->
+  if String.isEmpty s
+  then Validation.invalid "String should not be empty."
+  else Validation.valid s
+
+requiredId : String -> Field String (Id a)
+requiredId n = make n "" <| \s ->
+  case String.toInt s of
+    Nothing -> Validation.invalid "This is not a valid Id."
+    Just k -> Validation.valid (Id k)

--- a/csdc-gui/src/Input.elm
+++ b/csdc-gui/src/Input.elm
@@ -1,0 +1,50 @@
+module Input exposing
+  ( text
+  , radio
+  )
+
+import Field exposing (Field)
+
+import Element exposing (Element)
+import Element.Font as Font
+import Element.Input as Input
+
+text :
+  { onChange : String -> msg
+  , field : Field String a
+  } ->
+  Element msg
+text opts =
+  Element.column
+    [ Element.spacing 10 ]
+    [ Input.text
+        []
+        { onChange = opts.onChange
+        , placeholder = Nothing
+        , label = Input.labelAbove [] (Element.text (Field.name opts.field))
+        , text = Field.raw opts.field
+        }
+    , Element.column
+        [ Font.color (Element.rgb 1 0 0)
+        ]
+        (List.map Element.text (Field.errors opts.field))
+    ]
+
+
+radio :
+  { onChange : option -> msg
+  , options : List (option, String)
+  , field : Field (Maybe option) option
+  } ->
+  Element msg
+radio opts =
+  Input.radioRow
+    [ Element.padding 10
+    , Element.spacing 20
+    ]
+    { onChange = opts.onChange
+    , selected = Field.raw opts.field
+    , label = Input.labelAbove [] (Element.text (Field.name opts.field))
+    , options = List.map (\(a,b) -> Input.option a (Element.text b)) opts.options
+    }
+

--- a/csdc-gui/src/Validation.elm
+++ b/csdc-gui/src/Validation.elm
@@ -1,0 +1,38 @@
+module Validation exposing
+  ( Validation
+  , make
+  , validate
+  , valid
+  , invalid
+  , map
+  , andMap
+  )
+
+type Validation a = Validation (Result (List String) a)
+
+make : Result (List String) a -> Validation a
+make r = Validation r
+
+validate : Validation a -> Result (List String) a
+validate (Validation r) = r
+
+valid : a -> Validation a
+valid a = Validation (Ok a)
+
+invalid : String -> Validation a
+invalid s = Validation (Err [s])
+
+map : (a -> b) -> Validation a -> Validation b
+map f (Validation r) = Validation (Result.map f r)
+
+andMap : Validation a -> Validation (a -> b) -> Validation b
+andMap (Validation r) (Validation f) = Validation <|
+  case r of
+   Err er ->
+     case f of
+       Err ef -> Err (er ++ ef)
+       Ok _ -> Err er
+   Ok a ->
+     case f of
+       Err ef -> Err ef
+       Ok g -> Ok (g a)


### PR DESCRIPTION
This PR introduces three new modules:

- `Field`, which defines an abstraction for a form field, which is names and has a validation status.
- `Input`, which uses `Field` to give user feedback on the validation of the field.
- `Validation`, which is an applicative that accumulates errors on form validation. This means that when a form is validated on submission, all validation errors will appear, not only the first one.

This PR also converts all the forms in the GUI (basically those in the Admin panel) to use this new framework.

@Sedrun This PR changes the validation method, and greatly simplifies it. Make sure to update your branch.