### PR TITLE
Database setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ www/*.js
 secret.json
 client_session_key.aes
 admin-cookies
+.docker

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ serve: ## Launch the server.
 ################################################################################
 # GUI
 
-gui-build: ## Build the GUI into www/app.js
+gui-build: ## Build the GUI into www/app.js.
 	mkdir -p www
 	cd csdc-gui && elm make src/Main.elm --output ../www/app.js
 
@@ -56,6 +56,30 @@ elm-nix-update: ## Update Nix files for Elm.
 	cd csdc-gui && elm2nix convert > elm-srcs.nix
 
 .PHONY: elm-nix-update
+
+################################################################################
+# Database
+
+psql: ## Launch psql with the correct arguments.
+	PGHOST=localhost PGDATABASE=csdc PGPASSWORD=csdc PGPORT=5432 PGUSER=csdc psql
+
+.PHONY: psql
+
+################################################################################
+# Docker
+
+docker: ## Create and start the Docker image.
+	docker-compose --file database/postgresql.yml build
+	touch .docker
+	docker-compose --file database/postgresql.yml up -d
+
+.PHONY: docker
+
+docker-clean: ## Clean the Docker image.
+	docker-compose --file database/postgresql.yml down -v
+	rm -f .docker
+
+.PHONY: docker-clean
 
 ################################################################################
 # Help

--- a/database/postgresql.yml
+++ b/database/postgresql.yml
@@ -1,0 +1,35 @@
+# Based on https://github.com/khezen/compose-postgres
+
+version: '3.5'
+
+services:
+  db:
+    container_name: postgres_container_csdc
+    image: postgres:9.6-alpine
+    network_mode: "host"
+    restart: always
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: csdc
+      POSTGRES_DB: csdc
+      POSTGRES_PASSWORD: csdc
+
+  pgadmin:
+    container_name: pgadmin_container_csdc
+    network_mode: "host"
+    image: dpage/pgadmin4:4.10
+    environment:
+      SERVER_MODE: "False" # use desktop mode
+      PGADMIN_DEFAULT_EMAIL: csdc@csdc.com
+      PGADMIN_DEFAULT_PASSWORD: csdc
+      PGADMIN_LISTEN_PORT: 5555
+    volumes:
+      - pgadmin:/root/.pgadmin
+      # the servers.json file configures the database above
+      - ${PWD}/database/servers.json:/pgadmin4/servers.json
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  pgadmin:

--- a/database/servers.json
+++ b/database/servers.json
@@ -1,0 +1,12 @@
+{ "Servers":
+  { "1":
+    { "Name": "CSDC",
+      "Group": "Servers",
+      "Port": 5432,
+      "Username": "csdc",
+      "Host": "localhost",
+      "SSLMode": "prefer",
+      "MaintenanceDB": "csdc"
+    }
+  }
+}

--- a/default.nix
+++ b/default.nix
@@ -31,6 +31,9 @@ let
             elmPackages.elm
             elm2nix
             nodePackages.uglify-js
+            # Database
+            docker-compose
+            postgresql
           ];
       };
 in


### PR DESCRIPTION
This PR gives a docker-based setup of PostgreSQL.
To setup the database, just launch `make docker`.
The necessary dependencies have been added to the Nix shell.

First part of #10.