### PR TITLE
Add a Docker image that runs the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ secret.json
 client_session_key.aes
 admin-cookies
 .docker
+result

--- a/csdc-gui/default.nix
+++ b/csdc-gui/default.nix
@@ -31,7 +31,8 @@ let
         mkdir -p $out/share/doc
         ${lib.concatStrings (map (module: ''
           echo "compiling ${elmfile module}"
-          elm make ${elmfile module} --output $out/${module}.${extension} --docs $out/share/doc/${module}.json
+          # FIXME: index is hardcoded here.
+          elm make ${elmfile module} --output $out/index.${extension} --docs $out/share/doc/${module}.json
           ${lib.optionalString outputJavaScript ''
             echo "minifying ${elmfile module}"
             uglifyjs $out/${module}.${extension} --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters,keep_fargs=false,unsafe_comps,unsafe' \

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,28 @@
+# Deployment
+
+## Creating the Docker image
+
+To create the Docker image, do:
+
+```
+nix-build
+docker load < result
+```
+
+To run the image and have the server accessible at `localhost:8080`, run:
+
+```
+export SECRET_TOKEN=...
+export SECRET_ORCID_ID=...
+export SECRET_ORCID_SECRET=...
+docker run --rm \
+  -e SECRET_TOKEN -e SECRET_ORCID_ID -e SECRET_ORCID_SECRET \
+  -p 127.0.0.1:8080:8080/tcp \
+  csdc-dao
+```
+
+To inspect the Docker image, do:
+
+```
+docker run -it csdc-dao sh
+```

--- a/deployment/default.nix
+++ b/deployment/default.nix
@@ -1,0 +1,43 @@
+with import ../nix;
+
+let
+  # Local packages.
+  packages = import ../release.nix;
+
+  server = haskell.lib.justStaticExecutables packages.csdc-api;
+  gui = packages.csdc-gui;
+
+  # Server configuration.
+  writeJson = name: tree:
+    writeText name (builtins.toJSON tree);
+
+  config = writeJson "csdc-dao-config" {
+    port = 8080;
+    path = gui;
+    orcidEndpoint = "production";
+  };
+in
+  # We are using buildImage instead of buildLayeredImage because of the
+  # runAsRoot option. The Haskell http-client library is not aware of the
+  # SSL_SECRET_FILE environment variable, so we have to copy certificates to
+  # where it expects them to be, which can only be done as root.
+  dockerTools.buildImage {
+    name = "csdc-dao";
+    tag = "latest";
+    contents = [
+      server
+      busybox
+    ];
+    config = {
+      Cmd = [
+        "/bin/csdc-server" config
+      ];
+      ExposedPorts = {
+        "8080" = {};
+      };
+    };
+    runAsRoot = ''
+      mkdir -p /etc/ssl/certs
+      ln -s ${cacert}/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+    '';
+  }


### PR DESCRIPTION
This adds a Nix expression that produces a Docker image capable of running the server in its present state. That is, with a in-memory database.

This is the first step towards deploying it to Heroku, as described in #7.