### PR TITLE
Heroku deployment

### DIFF
--- a/csdc-gui/src/CSDC/API.elm
+++ b/csdc-gui/src/CSDC/API.elm
@@ -11,6 +11,8 @@ type alias Response a = Result Http.Error a
 
 baseUrl : String
 baseUrl = "http://localhost:8080/api/"
+--baseUrl = "http://csdc-dao-test.herokuapp.com/api/"
+
 
 decodeNull : D.Decoder ()
 decodeNull =

--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,8 @@ let
             # Database
             docker-compose
             postgresql
+            # Deployment
+            heroku
           ];
       };
 in

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -26,3 +26,39 @@ To inspect the Docker image, do:
 ```
 docker run -it csdc-dao sh
 ```
+
+## Deploying to Heroku
+
+First, log in to Heroku using:
+
+```
+heroku login
+```
+
+and login into the container registry:
+
+```
+heroku container:login
+```
+
+Build the Docker image and load it:
+
+```
+nix-build
+docker load < result
+```
+
+Tag the image conveniently, and push it:
+
+```
+docker tag csdc-dao registry.heroku.com/csdc-dao-test/web
+docker push registry.heroku.com/csdc-dao-test/web
+```
+
+and release it with Heroku:
+
+```
+heroku container:release -a csdc-dao-test web
+```
+
+

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+nix-build
+docker load < result
+docker tag csdc-dao registry.heroku.com/csdc-dao-test/web
+docker push registry.heroku.com/csdc-dao-test/web
+heroku container:release -a csdc-dao-test web


### PR DESCRIPTION
This adds the scripts necessary to deploy the CSDC DAO to Heroku, as a free app, in http://csdc-dao-test.herokuapp.com/.
This does not cover the database, which will be setup later.

A problem encountered along the way is that the GUI API URL is hardcoded in `API.elm`.
For the deployment this was changed manually, but I need to find a better solution later.
Something that may help: https://blog.leif.io/configure-your-elm-app-with-env-variables/

@paulbourgine @Sedrun

Closes #7 for the moment.

