### PR TITLE
Relative API root

### DIFF
--- a/csdc-gui/src/CSDC/API.elm
+++ b/csdc-gui/src/CSDC/API.elm
@@ -10,9 +10,7 @@ import Json.Decode as D
 type alias Response a = Result Http.Error a
 
 baseUrl : String
-baseUrl = "http://localhost:8080/api/"
---baseUrl = "http://csdc-dao-test.herokuapp.com/api/"
-
+baseUrl = "/api/"
 
 decodeNull : D.Decoder ()
 decodeNull =


### PR DESCRIPTION
This PR sets the API root for the Elm app as relative, instead of absolute. This makes the setup much simpler, since the same code can be used both in development in production. We may want to change this later, but this is good for now.