### PR TITLE
Add SQL configuration in Haskell code

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,10 @@
 { "port": 8080
 , "path": "www"
 , "orcidEndpoint": "production"
+, "sql":
+    { "host": "localhost"
+    , "port": 5432
+    , "user": "csdc"
+    , "database": "csdc"
+    }
 }

--- a/csdc-api/csdc-api.cabal
+++ b/csdc-api/csdc-api.cabal
@@ -25,6 +25,8 @@ common dependencies
     base,
     bytestring,
     ghc-prim,
+    hasql,
+    mtl,
     servant,
     servant-server,
     text,
@@ -51,6 +53,7 @@ library
     CSDC.Config
     CSDC.API
     CSDC.API.DAO
+    CSDC.SQL
   hs-source-dirs:
     src
   ghc-options:

--- a/csdc-api/src/CSDC/SQL.hs
+++ b/csdc-api/src/CSDC/SQL.hs
@@ -1,6 +1,10 @@
 module CSDC.SQL
-  ( -- * Config
+  ( -- * Config and Secret
     Config (..)
+  , Secret (..)
+    -- * Context
+  , Context
+  , activate
     -- * Error
   , Error (..)
     -- * Action
@@ -9,9 +13,12 @@ module CSDC.SQL
   , query
   ) where
 
+import CSDC.Prelude
+
 import Control.Exception (Exception, finally, throwIO, try)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Reader (ReaderT (..), MonadReader (..))
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Text (Text)
 import Hasql.Connection (Connection, ConnectionError)
 import Hasql.Session (QueryError)
@@ -22,16 +29,37 @@ import qualified Hasql.Connection as Connection
 import qualified Hasql.Session as Session
 
 --------------------------------------------------------------------------------
--- Config
+-- Config and Secret
 
 -- | The configuration of the PostgreSQL server.
 data Config = Config
   { config_host :: Text
   , config_port :: Int
   , config_user :: Text
-  , config_password :: Text
   , config_database :: Text
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Generic)
+    deriving (FromJSON, ToJSON) via JSON Config
+
+-- | The secrets of the PostgreSQL server.
+data Secret = Secret
+  { secret_password :: Text
+  } deriving (Show, Eq, Generic)
+    deriving (FromJSON, ToJSON) via JSON Secret
+
+--------------------------------------------------------------------------------
+-- Context
+
+-- | The context of the PostgreSQL server.
+data Context = Context
+  { context_config :: Config
+  , context_secret :: Secret
+  } deriving (Show, Eq, Generic)
+    deriving (FromJSON, ToJSON) via JSON Context
+
+-- | Activate the configuration.
+-- TODO: Check the validity of the configuration.
+activate :: Config -> Secret -> IO Context
+activate config secret = pure $ Context config secret
 
 --------------------------------------------------------------------------------
 -- Error
@@ -52,14 +80,14 @@ newtype Action a = Action (ReaderT Connection IO a)
   deriving (Functor, Applicative, Monad)
 
 -- | Run a SQL action and return possible errors.
-run :: MonadIO m => Config -> Action a -> m (Either Error a)
-run config (Action m) = liftIO $ do
+run :: MonadIO m => Context -> Action a -> m (Either Error a)
+run (Context config secret) (Action m) = liftIO $ do
   let settings =
         Connection.settings
           (Text.Encoding.encodeUtf8 $ config_host config)
           (fromIntegral $ config_port config)
           (Text.Encoding.encodeUtf8 $ config_user config)
-          (Text.Encoding.encodeUtf8 $ config_password config)
+          (Text.Encoding.encodeUtf8 $ secret_password secret)
           (Text.Encoding.encodeUtf8 $ config_database config)
 
   Connection.acquire settings >>= \case

--- a/csdc-api/src/CSDC/SQL.hs
+++ b/csdc-api/src/CSDC/SQL.hs
@@ -1,0 +1,81 @@
+module CSDC.SQL
+  ( -- * Config
+    Config (..)
+    -- * Error
+  , Error (..)
+    -- * Action
+  , Action (..)
+  , run
+  , query
+  ) where
+
+import Control.Exception (Exception, finally, throwIO, try)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Reader (ReaderT (..), MonadReader (..))
+import Data.Text (Text)
+import Hasql.Connection (Connection, ConnectionError)
+import Hasql.Session (QueryError)
+import Hasql.Statement (Statement)
+
+import qualified Data.Text.Encoding as Text.Encoding
+import qualified Hasql.Connection as Connection
+import qualified Hasql.Session as Session
+
+--------------------------------------------------------------------------------
+-- Config
+
+-- | The configuration of the PostgreSQL server.
+data Config = Config
+  { config_host :: Text
+  , config_port :: Int
+  , config_user :: Text
+  , config_password :: Text
+  , config_database :: Text
+  } deriving (Show, Eq)
+
+--------------------------------------------------------------------------------
+-- Error
+
+-- | The errors that can be emitted from SQL actions.
+data Error
+  = ErrorConnection ConnectionError
+  | ErrorQuery QueryError
+    deriving (Show, Eq)
+
+instance Exception Error
+
+--------------------------------------------------------------------------------
+-- Action
+
+-- | An action performing SQL operations.
+newtype Action a = Action (ReaderT Connection IO a)
+  deriving (Functor, Applicative, Monad)
+
+-- | Run a SQL action and return possible errors.
+run :: MonadIO m => Config -> Action a -> m (Either Error a)
+run config (Action m) = liftIO $ do
+  let settings =
+        Connection.settings
+          (Text.Encoding.encodeUtf8 $ config_host config)
+          (fromIntegral $ config_port config)
+          (Text.Encoding.encodeUtf8 $ config_user config)
+          (Text.Encoding.encodeUtf8 $ config_password config)
+          (Text.Encoding.encodeUtf8 $ config_database config)
+
+  Connection.acquire settings >>= \case
+    Left err ->
+      pure $ Left $ ErrorConnection err
+
+    Right conn ->
+      try (runReaderT m conn) `finally` (Connection.release conn)
+
+-- | Lift a SQL statement into an action.
+query :: Statement a b -> a -> Action b
+query stm a = Action $ do
+  conn <- ask
+  let session = Session.statement a stm
+  liftIO (Session.run session conn) >>= \case
+    Left err ->
+      liftIO $ throwIO $ ErrorQuery err
+    Right res ->
+      pure res

--- a/secret-model.json
+++ b/secret-model.json
@@ -1,4 +1,7 @@
 { "token": "some_token"
 , "orcidId": "orcid_id"
 , "orcidSecret": "orcid_secret"
+, "sql":
+    { "password": "csdc"
+    }
 }


### PR DESCRIPTION
This adds the SQL configuration parser and runner in the Haskell server.
Prelude to the SQL implementation of the server.