### PR TITLE
haskell-language-server is now compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ In particular:
 
   - For Elm development, there is `make gui-build`.
 
+## Haskell Language Server with VSCode
+You have to install cabal "for real" because the language server doesn't run in the Nix environment.
+
+Then run this command:
+```
+cabal update
+```
+
+Finally, install [the extension](https://marketplace.visualstudio.com/items?itemName=haskell.haskell).
 ## Running the server
 
 First, make sure the GUI is built with:

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,16 @@
+cradle:
+  cabal:
+    - path: "csdc-api/src"
+      component: "lib:csdc-api"
+
+    - path: "csdc-api/app"
+      component: "exe:csdc-server"
+
+    - path: "csdc-auth/app"
+      component: "exe:auth-test-server"
+
+    - path: "csdc-auth/src"
+      component: "lib:csdc-auth"
+
+    - path: "csdc-base/src"
+      component: "lib:csdc-base"


### PR DESCRIPTION
The language server (LS) now runs correctly within the project ([the documentation I used](https://haskell-language-server.readthedocs.io/en/latest/configuration.html#configuring-your-project-build)). However, the LS doesn't care about `nix/overlay.nix` so some dependencies are not used correctly like the `hoauth2` fork from https://github.com/guaraqe/hoauth2. I don't know if there is a "pure cabal" solution for doing that. We can still use the real dependencies, I did that in my previous "stack only" fork and the project still compiled (with some code changes).