### PR TITLE
Add daemon that computes election winners

### DIFF
--- a/csdc-api/app/Main.hs
+++ b/csdc-api/app/Main.hs
@@ -3,6 +3,7 @@
 
 module Main where
 
+import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import CSDC.API (serveAPI)
 import CSDC.API.Auth qualified as Auth
@@ -10,6 +11,7 @@ import CSDC.Action qualified as Action
 import CSDC.Config (Context (..), activate, readConfig, showConfig)
 import CSDC.Daemon qualified as Daemon
 import CSDC.Daemon.Mail qualified as Daemon.Mail
+import CSDC.Daemon.Election qualified as Daemon.Election
 import CSDC.SQL qualified as SQL
 import CSDC.SQL.Subparts qualified as SQL.Subparts
 import Network.Wai (Middleware)
@@ -58,8 +60,9 @@ main = do
 mainWith :: Context -> IO ()
 mainWith Context {..} = do
   putStrLn "Starting mail daemon..."
-  _ <- Action.run_ dao $ do
-    Daemon.launch Daemon.Mail.daemon
+  void $ Action.run_ dao $ Daemon.launch Daemon.Mail.daemon
+  putStrLn "Starting election daemon..."
+  void $ Action.run_ dao $ Daemon.launch Daemon.Election.daemon
   putStrLn "Server ready."
   withStdoutLogger $ \logger -> do
     let settings = setPort port $ setLogger logger defaultSettings

--- a/csdc-api/csdc-api.cabal
+++ b/csdc-api/csdc-api.cabal
@@ -50,6 +50,7 @@ common dependencies
     time,
     typed-process,
     unliftio,
+    unordered-containers,
     wai,
     wai-app-static,
     wai-extra,
@@ -81,6 +82,7 @@ library
     CSDC.Action
     CSDC.Config
     CSDC.Daemon
+    CSDC.Daemon.Election
     CSDC.Daemon.Mail
     CSDC.API
     CSDC.API.Auth

--- a/csdc-api/src/CSDC/Daemon/Election.hs
+++ b/csdc-api/src/CSDC/Daemon/Election.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MultiWayIf #-}
+
+module CSDC.Daemon.Election
+  ( daemon,
+  )
+where
+
+import CSDC.Action
+import CSDC.Daemon (Daemon)
+import CSDC.Daemon qualified as Daemon
+import CSDC.SQL.Elections qualified as SQL.Elections
+import CSDC.Types.Election
+import Control.Monad (forM_)
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as HashMap
+import Data.Monoid (Sum (..))
+
+-- | A daemon that checks the e-mail queue and tries to send them. If
+-- successful, remove them from the queue.
+daemon :: Daemon (Action user)
+daemon = Daemon.make 5 "Election" $ do
+  pairs <- runQuery SQL.Elections.selectResolvableElections ()
+
+  forM_ pairs $ \(electionId, election) -> do
+
+    votes <- runQuery SQL.Elections.selectElectionVotes electionId
+
+    let toGradedVote :: VotePayload -> HashMap ElectionChoice (Sum Int)
+        toGradedVote vote = case election.electionType of
+          MajorityConsensus ->
+            let
+              fromGrade = \case
+                GradeExcellent -> Sum 3
+                GradeVeryGood -> Sum 2
+                GradeGood -> Sum 1
+                GradeAcceptable -> Sum 0
+                GradeBad -> Sum (-1)
+                GradeVeryBad -> Sum (-2)
+            in
+              case vote of
+                VotePayloadMajorityConsensus grades -> fmap fromGrade grades
+                _ -> mempty
+
+          SimpleMajority ->
+            let
+              fromGrade = \case
+                Nothing -> mempty
+                Just choice -> HashMap.singleton choice (Sum 1)
+            in
+              case vote of
+                VotePayloadSimpleMajority choice -> fromGrade choice
+                _ -> mempty
+
+        summary :: HashMap ElectionChoice (Sum Int)
+        summary = mconcat $ fmap toGradedVote votes
+
+        accumulate ::
+          (Sum Int, [ElectionChoice]) ->
+          ElectionChoice ->
+          Sum Int ->
+          (Sum Int, [ElectionChoice])
+        accumulate (winnersGrade, winners) choice choiceGrade =
+          if | winnersGrade == choiceGrade -> (winnersGrade, choice:winners)
+             | winnersGrade < choiceGrade -> (choiceGrade, [choice])
+             | otherwise -> (winnersGrade, winners)
+
+        (_,wins) = HashMap.foldlWithKey accumulate (Sum (-1000),[]) summary
+
+        result = case wins of
+          [winner] -> Just winner
+          _ -> Nothing
+
+    runQuery SQL.Elections.updateElectionResult (electionId, result)

--- a/csdc-api/src/CSDC/SQL/Decoder.hs
+++ b/csdc-api/src/CSDC/SQL/Decoder.hs
@@ -18,6 +18,7 @@ module CSDC.SQL.Decoder
     electionChoiceList,
     electionChoiceNullable,
     electionType,
+    votePayload,
 
     -- * Reexport
     Decoders.rowList,
@@ -29,7 +30,9 @@ where
 
 import CSDC.Prelude
 import CSDC.Types.Election
+import Data.Aeson qualified as JSON
 import Data.ByteString (ByteString)
+import Data.Text qualified as Text
 import Data.Time.Clock.POSIX (POSIXTime, utcTimeToPOSIXSeconds)
 import Hasql.Decoders (Row, column, listArray, nonNullable, nullable)
 import Hasql.Decoders qualified as Decoders
@@ -128,3 +131,10 @@ electionType = column (nonNullable (Decoders.enum decode))
         [ ("SimpleMajority", SimpleMajority),
           ("MajorityConsensus", MajorityConsensus)
         ]
+
+votePayload :: Row VotePayload
+votePayload = column (nonNullable (Decoders.refine fromJSON Decoders.jsonb))
+  where
+    fromJSON a = case JSON.fromJSON a of
+      JSON.Error e -> Left (Text.pack e)
+      JSON.Success s -> Right s

--- a/csdc-api/src/CSDC/SQL/Encoder.hs
+++ b/csdc-api/src/CSDC/SQL/Encoder.hs
@@ -16,6 +16,7 @@ module CSDC.SQL.Encoder
     messageStatus,
     replyType,
     replyStatus,
+    electionChoiceNullable,
     electionChoiceList,
     electionType,
     votePayload,
@@ -115,6 +116,9 @@ electionType = contramap encode text
   where
     encode SimpleMajority = "SimpleMajority"
     encode MajorityConsensus = "MajorityConsensus"
+
+electionChoiceNullable :: Params (Maybe ElectionChoice)
+electionChoiceNullable = contramap (fmap (.getElectionChoice)) textNullable
 
 electionChoiceList :: Params [ElectionChoice]
 electionChoiceList = contramap (fmap (.getElectionChoice)) textList

--- a/csdc-base/csdc-base.cabal
+++ b/csdc-base/csdc-base.cabal
@@ -48,15 +48,12 @@ library
     src
   default-extensions:
     DeriveAnyClass
-    DeriveGeneric
     DerivingStrategies
     DerivingVia
     DuplicateRecordFields
-    GeneralizedNewtypeDeriving
     NoFieldSelectors
     OverloadedRecordDot
-    ImportQualifiedPost
   ghc-options:
     -Wall
   default-language:
-    Haskell2010
+    GHC2021


### PR DESCRIPTION
This adds a daemon, i.e., a background process, that periodically checks for elections that ended and computes their results. The one for Majority Judgement is probably wrong, but the goal was to put the code in the right place already. We can check how to use Armand's code instead later. I tested with a simple majority one and it worked.