### PR TITLE
Add query to retrieve extended children of units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ serve: ## Launch the server.
 
 .PHONY: serve
 
+TEST_ARGS=
+
+serve-test: ## Launch the test script in the server app.
+	mkdir -p tmp
+	cabal run --ghc-options="-O0" -- csdc-server test --config=config.json $(TEST_ARGS)
+
+.PHONY: serve-test
+
 ################################################################################
 # GUI
 

--- a/csdc-api/src/CSDC/DAO.hs
+++ b/csdc-api/src/CSDC/DAO.hs
@@ -329,6 +329,11 @@ getUnitInfo uid = do
       parents <- getUnitParents uid
       unitsForMessage <-
         runQuery SQL.MessageSubparts.getUnitsForMessage (userId, uid)
+      let isMember = any (\m -> m.personId == userId) members
+      isIndirectMember <-
+        if False --isMember
+          then pure True
+          else runQuery SQL.Members.isIndirectMember (userId, uid)
       pure $
         Just
           UnitInfo
@@ -339,7 +344,8 @@ getUnitInfo uid = do
               parents = parents,
               userId = userId,
               isAdmin = unit.chairId == userId,
-              isMember = any (\m -> m.personId == userId) members,
+              isMember = isMember,
+              isIndirectMember = isIndirectMember,
               isMembershipPending = isMembershipPending,
               unitsForMessage = unitsForMessage
             }

--- a/csdc-api/src/CSDC/SQL/Subparts.hs
+++ b/csdc-api/src/CSDC/SQL/Subparts.hs
@@ -126,7 +126,7 @@ selectByExtendedParent = Statement sql encoder decoder True
             UNION
             SELECT d.id, d.parent, s.child, d.level + 1
             FROM descendants d JOIN subparts s ON d.child=s.parent
-        )
+        ) SEARCH DEPTH FIRST BY parent SET ordercol
         SELECT descendants.id, level, child, units.name, units.description, units.chair, units.image, units.created_at
         FROM descendants JOIN units ON units.id = child
         WHERE parent = $1

--- a/csdc-api/src/CSDC/SQL/Subparts.hs
+++ b/csdc-api/src/CSDC/SQL/Subparts.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 module CSDC.SQL.Subparts
@@ -8,12 +9,14 @@ module CSDC.SQL.Subparts
     insert,
     delete,
     deleteUnit,
+    selectByExtendedParent,
   )
 where
 
 import CSDC.Prelude
 import CSDC.SQL.Decoder qualified as Decoder
 import CSDC.SQL.Encoder qualified as Encoder
+import CSDC.SQL.QQ (sqlqq)
 import Data.ByteString.Char8 qualified as ByteString
 import Data.Functor.Contravariant (Contravariant (..))
 import Hasql.Statement (Statement (..))
@@ -33,6 +36,7 @@ selectByChild = Statement sql encoder decoder True
 
     decoder = Decoder.rowList $ do
       subpartId <- Decoder.id
+      let level = 1
       unitId <- Decoder.id
       unit <- do
         name <- Decoder.text
@@ -58,6 +62,7 @@ selectByParent = Statement sql encoder decoder True
 
     decoder = Decoder.rowList $ do
       subpartId <- Decoder.id
+      let level = 1
       unitId <- Decoder.id
       unit <- do
         name <- Decoder.text
@@ -109,3 +114,35 @@ deleteUnit = Statement sql encoder decoder True
     encoder = Encoder.id
 
     decoder = Decoder.noResult
+
+selectByExtendedParent :: Statement (Id Unit) [UnitSubpart]
+selectByExtendedParent = Statement sql encoder decoder True
+  where
+    sql =
+      [sqlqq|
+        WITH RECURSIVE descendants(id, parent, child) AS (
+            SELECT id, parent, child, 1 as level
+            FROM subparts
+            UNION
+            SELECT d.id, d.parent, s.child, d.level + 1
+            FROM descendants d JOIN subparts s ON d.child=s.parent
+        )
+        SELECT descendants.id, level, child, units.name, units.description, units.chair, units.image, units.created_at
+        FROM descendants JOIN units ON units.id = child
+        WHERE parent = $1
+      |]
+
+    encoder = Encoder.id
+
+    decoder = Decoder.rowList $ do
+      subpartId <- Decoder.id
+      level <- Decoder.int
+      unitId <- Decoder.id
+      unit <- do
+        name <- Decoder.text
+        description <- Decoder.text
+        chairId <- Decoder.id
+        image <- Decoder.text
+        createdAt <- Decoder.posixTime
+        pure Unit {..}
+      pure UnitSubpart {..}

--- a/csdc-base/src/CSDC/Types/GUI.hs
+++ b/csdc-base/src/CSDC/Types/GUI.hs
@@ -64,6 +64,7 @@ data UnitMember = UnitMember
 
 data UnitSubpart = UnitSubpart
   { subpartId :: Id Subpart,
+    level :: Int,
     unitId :: Id Unit,
     unit :: Unit
   }

--- a/csdc-base/src/CSDC/Types/GUI.hs
+++ b/csdc-base/src/CSDC/Types/GUI.hs
@@ -79,6 +79,7 @@ data UnitInfo = UnitInfo
     parents :: [UnitSubpart],
     userId :: Id Person,
     isMember :: Bool,
+    isIndirectMember :: Bool,
     isAdmin :: Bool,
     isMembershipPending :: Bool,
     unitsForMessage :: [WithId Unit]

--- a/csdc-base/src/CSDC/Types/Id.hs
+++ b/csdc-base/src/CSDC/Types/Id.hs
@@ -18,7 +18,7 @@ import Web.Internal.HttpApiData (FromHttpApiData (..))
 
 -- | A unique identifier for some type.
 newtype Id a = Id {getId :: UUID}
-  deriving newtype (Show, Eq, Ord, ToJSON, FromJSON)
+  deriving newtype (Show, Read, Eq, Ord, ToJSON, FromJSON)
 
 instance FromHttpApiData (Id a) where
   parseUrlPiece txt =

--- a/csdc-gui/src/Types.elm
+++ b/csdc-gui/src/Types.elm
@@ -270,6 +270,7 @@ type alias UnitInfo =
   , parents : List UnitSubpart
   , userId : Id Person
   , isMember : Bool
+  , isIndirectMember : Bool
   , isAdmin : Bool
   , isMembershipPending : Bool
   , unitsForMessage : List (WithId Unit)
@@ -285,6 +286,7 @@ decodeUnitInfo =
     |> andMap (Decoder.field "parents" (Decoder.list decodeUnitSubpart))
     |> andMap (Decoder.field "userId" decodeId)
     |> andMap (Decoder.field "isMember" Decoder.bool)
+    |> andMap (Decoder.field "isIndirectMember" Decoder.bool)
     |> andMap (Decoder.field "isAdmin" Decoder.bool)
     |> andMap (Decoder.field "isMembershipPending" Decoder.bool)
     |> andMap (Decoder.field "unitsForMessage" (Decoder.list (decodeWithId decodeUnit)))

--- a/csdc-gui/src/Types.elm
+++ b/csdc-gui/src/Types.elm
@@ -249,14 +249,16 @@ decodeUnitMember =
 
 type alias UnitSubpart =
   { subpartId : Id Subpart
+  , level : Int
   , unitId : Id Unit
   , unit : Unit
   }
 
 decodeUnitSubpart : Decoder UnitSubpart
 decodeUnitSubpart =
-  Decoder.map3 UnitSubpart
+  Decoder.map4 UnitSubpart
     (Decoder.field "subpartId" decodeId)
+    (Decoder.field "level" Decoder.int)
     (Decoder.field "unitId" decodeId)
     (Decoder.field "unit" decodeUnit)
 

--- a/database/migrations/002-trigger-no-cycles.sql
+++ b/database/migrations/002-trigger-no-cycles.sql
@@ -1,0 +1,27 @@
+CREATE OR REPLACE FUNCTION detect_cycle()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql AS
+$func$
+BEGIN
+  IF EXISTS (
+      WITH RECURSIVE descendants(parent, child) AS (
+          SELECT parent, child as level
+          FROM subparts
+          UNION
+          SELECT d.parent, s.child
+          FROM descendants d JOIN subparts s ON d.child=s.parent
+      ) CYCLE child SET is_cycle USING path
+      SELECT * FROM descendants
+      WHERE parent = NEW.parent AND is_cycle IS TRUE
+  )
+  THEN
+    RAISE EXCEPTION 'Loop detected';
+  ELSE
+    RETURN NEW;
+  END IF;
+END
+$func$;
+
+CREATE CONSTRAINT TRIGGER detect_subparts_cycle
+AFTER INSERT OR UPDATE ON subparts
+FOR EACH ROW EXECUTE PROCEDURE detect_cycle();

--- a/database/postgresql.yml
+++ b/database/postgresql.yml
@@ -5,7 +5,7 @@ version: '3.5'
 services:
   db:
     container_name: postgres_container_csdc
-    image: postgres:9.6-alpine
+    image: postgres:14.7-alpine
     network_mode: "host"
     restart: always
     volumes:


### PR DESCRIPTION
For now, we are developing elections whose scope is only the members of an unit, but we would like to be able to make elections where the whose sub-hierarchy of an unit can participate.

This PR adds a query that retrieves all the extended children of an unit, that is all of subunits of subunits, etc... This is a first step towards that.

To test the request, you can create the desired hierarchy using the UI, find the ID of the unit you want to make the request for (it's in the URL, such as 6cbdb45c-0692-429d-a9b8-fed2de6959ac) and run the command:

```
make serve-test TEST_ARGS=--unitId=6cbdb45c-0692-429d-a9b8-fed2de6959ac
```