### PR TITLE
Add Majority Consensus to shell and server

### DIFF
--- a/csdc-api/csdc-api.cabal
+++ b/csdc-api/csdc-api.cabal
@@ -25,6 +25,7 @@ common dependencies
     binary,
     base64-bytestring,
     bytestring,
+    cassava,
     directory,
     filepath,
     ghc-prim,
@@ -38,6 +39,7 @@ common dependencies
     network-uri,
     optparse-generic,
     password,
+    process,
     random,
     resource-pool,
     servant,
@@ -94,6 +96,7 @@ library
     CSDC.Mail
     CSDC.Mail.Templates
     CSDC.Mail.Templates.TH
+    CSDC.MajorityJudgement
     CSDC.SQL
     CSDC.SQL.Decoder
     CSDC.SQL.Encoder

--- a/csdc-api/src/CSDC/DAO.hs
+++ b/csdc-api/src/CSDC/DAO.hs
@@ -8,6 +8,7 @@ import CSDC.Action
 import CSDC.Image
 import CSDC.Mail qualified as Mail
 import CSDC.Mail.Templates qualified as Mail.Templates
+import CSDC.MajorityJudgement qualified as MajorityJudgement
 import CSDC.Prelude
 import CSDC.SQL.Elections qualified as SQL.Elections
 import CSDC.SQL.Files qualified as SQL.Files
@@ -24,8 +25,8 @@ import CSDC.Types.Election
 import CSDC.Types.File
 import Control.Monad (forM_)
 import Control.Monad.Reader (asks)
-import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HashMap
+import Data.Maybe (mapMaybe)
 import Data.Monoid (Sum (..))
 import Data.Password.Bcrypt (hashPassword, mkPassword)
 import Data.Text qualified as Text
@@ -480,40 +481,32 @@ getElectionSummary :: Id Election -> Election -> Action user ElectionSummary
 getElectionSummary electionId election = do
   votes <- runQuery SQL.Elections.selectElectionVotes electionId
 
-  let toGradedVote :: VotePayload -> HashMap ElectionChoice (Sum Int)
-      toGradedVote vote = case election.electionType of
-        -- XXX: This is wrong, use instead Armand's software.
-        MajorityConsensus ->
-          let fromGrade = \case
-                GradeExcellent -> Sum 3
-                GradeVeryGood -> Sum 2
-                GradeGood -> Sum 1
-                GradeAcceptable -> Sum 0
-                GradeBad -> Sum (-1)
-                GradeVeryBad -> Sum (-2)
-           in case vote of
-                VotePayloadMajorityConsensus grades -> fmap fromGrade grades
-                _ -> mempty
-        SimpleMajority ->
-          let fromGrade = \case
-                Nothing -> mempty
-                Just choice -> HashMap.singleton choice (Sum 1)
-           in case vote of
-                VotePayloadSimpleMajority choice -> fromGrade choice
-                _ -> mempty
+  summary <- case election.electionType of
+    SimpleMajority ->
+      let fromGrade = \case
+            Nothing -> mempty
+            Just choice -> HashMap.singleton choice (Sum 1)
 
-      summary :: HashMap ElectionChoice (Sum Int)
-      summary = mconcat $ fmap toGradedVote votes
+          toGradedVote = \case
+            VotePayloadSimpleMajority choice -> fromGrade choice
+            _ -> mempty
+       in pure $ fmap getSum $ mconcat $ fmap toGradedVote votes
+    MajorityConsensus ->
+      let toGrade (VotePayloadMajorityConsensus a) = Just a
+          toGrade _ = Nothing
 
-  pure $ ElectionSummary $ fmap (fromIntegral . getSum) summary
+          grades = mapMaybe toGrade votes
+       in liftIO $ MajorityJudgement.summarizeGrades grades
+
+  pure $ ElectionSummary summary
 
 getElectionResult :: ElectionSummary -> Maybe ElectionChoice
 getElectionResult (ElectionSummary summary) =
   let accumulate ::
-        (Double, [ElectionChoice]) ->
+        (Int, [ElectionChoice]) ->
         ElectionChoice ->
-        Double ->
-        (Double, [ElectionChoice])
+        Int ->
+        (Int, [ElectionChoice])
       accumulate (winnersGrade, winners) choice choiceGrade =
         if
             | winnersGrade == choiceGrade -> (winnersGrade, choice : winners)

--- a/csdc-api/src/CSDC/MajorityJudgement.hs
+++ b/csdc-api/src/CSDC/MajorityJudgement.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module CSDC.MajorityJudgement
+  ( summarizeGrades,
+  )
+where
+
+import CSDC.Types.Election
+import Data.ByteString.Lazy.Char8 qualified as ByteString
+import Data.Char (ord)
+import Data.Csv
+import Data.Foldable (foldl', toList)
+import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict qualified as HashMap
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Debug.Trace
+import System.Process (readProcess)
+
+--------------------------------------------------------------------------------
+-- Execute command
+
+summarizeGrades :: [HashMap ElectionChoice Grade] -> IO (HashMap ElectionChoice Int)
+summarizeGrades votes = do
+  let grades = mergeGrades votes
+  output <- readProcess "majority-judgement" [] $ traceShowId $ toInput grades
+  pure $ fromOutput output
+
+--------------------------------------------------------------------------------
+-- Merging grades
+
+data Grades = Grades
+  { excellent :: Int,
+    veryGood :: Int,
+    good :: Int,
+    acceptable :: Int,
+    bad :: Int,
+    veryBad :: Int
+  }
+
+zero :: Grades
+zero = Grades 0 0 0 0 0 0
+
+add :: Grades -> Grades -> Grades
+add (Grades e1 vg1 g1 a1 b1 vb1) (Grades e2 vg2 g2 a2 b2 vb2) =
+  Grades (e1 + e2) (vg1 + vg2) (g1 + g2) (a1 + a2) (b1 + b2) (vb1 + vb2)
+
+fromGrade :: Grade -> Grades
+fromGrade = \case
+  GradeExcellent -> zero {excellent = 1}
+  GradeVeryGood -> zero {veryGood = 1}
+  GradeGood -> zero {good = 1}
+  GradeAcceptable -> zero {acceptable = 1}
+  GradeBad -> zero {bad = 1}
+  GradeVeryBad -> zero {veryBad = 1}
+
+mergeGrades :: [HashMap ElectionChoice Grade] -> HashMap ElectionChoice Grades
+mergeGrades = foldl' (HashMap.unionWith add) HashMap.empty . fmap (fmap fromGrade)
+
+--------------------------------------------------------------------------------
+-- Input and output
+
+toLine :: (ElectionChoice, Grades) -> NamedRecord
+toLine (ElectionChoice choice, Grades {..}) =
+  [ ("Candidates", toField choice),
+    ("Reject", toField veryBad),
+    ("Poor", toField bad),
+    ("Acceptable", toField acceptable),
+    ("Good", toField good),
+    ("VeryGood", toField veryGood),
+    ("Excellent", toField excellent)
+  ]
+
+toInput :: HashMap ElectionChoice Grades -> String
+toInput =
+  let csvOptions =
+        defaultEncodeOptions
+          { encUseCrLf = False
+          }
+      csvHeader =
+        [ "Candidates",
+          "Reject",
+          "Poor",
+          "Acceptable",
+          "Good",
+          "VeryGood",
+          "Excellent"
+        ]
+   in ByteString.unpack
+        . encodeByNameWith csvOptions csvHeader
+        . fmap toLine
+        . HashMap.toList
+
+fromOutput :: String -> HashMap ElectionChoice Int
+fromOutput output =
+  let decodeOptions =
+        defaultDecodeOptions
+          { decDelimiter = fromIntegral (ord '\t')
+          }
+
+      toPair hmap =
+        ( ElectionChoice $ hmap HashMap.! "Candidates",
+          read $ Text.unpack $ hmap HashMap.! "Grades"
+        )
+   in case decodeByNameWith @(HashMap Field Text) decodeOptions (ByteString.pack output) of
+        Left e ->
+          error e
+        Right (_, vals) ->
+          HashMap.fromList $ fmap toPair $ toList vals

--- a/csdc-base/src/CSDC/Types/Election.hs
+++ b/csdc-base/src/CSDC/Types/Election.hs
@@ -96,4 +96,4 @@ data Voter = Voter
 --------------------------------------------------------------------------------
 -- Summary
 
-newtype ElectionSummary = ElectionSummary (HashMap ElectionChoice Double)
+newtype ElectionSummary = ElectionSummary (HashMap ElectionChoice Int)

--- a/default.nix
+++ b/default.nix
@@ -44,6 +44,8 @@ let
             flyctl
             # IPFS
             ipfs
+            # Majority Judgement
+            majority-judgement
           ];
       };
 in

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -9,6 +9,24 @@ let
     sha256 = "sha256-eGZGxKU5mvzDrL2q2omIXzJjbjwvmQzh+eYukYzb3Dc=";
   };
 
+  majorityJudgementSrc = pkgs.fetchFromGitLab {
+    repo = "majorityconsensus";
+    owner = "armandguelina";
+    rev = "e7ea7b5ea59e4b41ff8aa2a82661de32d7f4cfd9";
+    sha256 = "sha256-uGmQQKcDqHV3usOKmpDLHB2GJmIpxVdJXuNI6+CE20c=";
+  };
+
+  majority-judgement = pkgs.writeShellScriptBin "majority-judgement" ''
+    tmpdir=$(mktemp -d /tmp/majority-judgement-votes.XXXXXX)
+    cd $tmpdir
+    touch input
+    while read line
+    do
+      echo "$line" >> input
+    done
+    ${pkgs.openjdk}/bin/java ${majorityJudgementSrc}/MajorityConsensus.java input 1
+  '';
+
   overrides = _: hspkgs: with pkgs.haskell.lib;
     {
       ipfs = hspkgs.callCabal2nix "ipfs" (pkgs.fetchFromGitHub {
@@ -30,4 +48,6 @@ in
         (old.overrides or (_: _: {}))
         overrides;
   });
+
+  majority-judgement = majority-judgement;
 }


### PR DESCRIPTION
This adds the majority consensus executable to the `nix-shell`, in a way that is convenient to be used by the software, namely:

```
cat input | majority-judgement
```